### PR TITLE
fix Trakt progress sync

### DIFF
--- a/docs/.vitepress/theme/components/mediaBridgeProviders.test.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeProviders.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createEmptyBundle } from './mediaBridgeCore.ts'
+import {
+  pushMediaBridge,
+  type BridgeConnection
+} from './mediaBridgeProviders.ts'
+
+function traktConnection(): BridgeConnection {
+  return {
+    slot: 'destination',
+    service: 'trakt',
+    accountId: 'test-account',
+    displayName: 'Test Trakt account',
+    credentials: {
+      service: 'trakt',
+      clientId: 'test-client',
+      tokens: {
+        access_token: 'test-token',
+        created_at: Math.floor(Date.now() / 1000),
+        expires_in: 3_600
+      },
+      refreshUrl: '/api/trakt/refresh'
+    }
+  }
+}
+
+function movieProgress(percentage: number, imdb = 'tt2015381') {
+  return {
+    media: {
+      kind: 'movie' as const,
+      ids: { imdb },
+      title: 'Almost Finished',
+      year: 2024
+    },
+    percentage,
+    updatedAt: Date.UTC(2026, 6, 17)
+  }
+}
+
+test('uses Trakt stop below 80 percent to create a paused resume point', async t => {
+  let requestUrl = ''
+  let requestBody: any = null
+  t.mock.method(globalThis, 'fetch', async (input, init) => {
+    requestUrl = String(input)
+    requestBody = JSON.parse(String(init?.body || '{}'))
+    return new Response(JSON.stringify({ action: 'pause', progress: requestBody.progress }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  })
+
+  const bundle = createEmptyBundle()
+  bundle.progress.push(movieProgress(79.9))
+  const result = await pushMediaBridge({
+    connection: traktConnection(),
+    bundle,
+    scopes: { history: false, progress: true, library: false }
+  })
+
+  assert.equal(new URL(requestUrl).pathname, '/scrobble/stop')
+  assert.equal(requestBody.progress, 79)
+  assert.equal(result.written.progress, 1)
+  assert.deepEqual(result.issues, [])
+})
+
+test('skips Trakt resume points at 80 percent or higher without writing history', async t => {
+  const fetchMock = t.mock.method(globalThis, 'fetch', async () => {
+    throw new Error('Trakt should not be called for completed progress.')
+  })
+
+  const bundle = createEmptyBundle()
+  bundle.progress.push(movieProgress(99))
+  const result = await pushMediaBridge({
+    connection: traktConnection(),
+    bundle,
+    scopes: { history: false, progress: true, library: false }
+  })
+
+  assert.equal(fetchMock.mock.callCount(), 0)
+  assert.equal(result.written.progress, 0)
+  assert.equal(result.issues.length, 1)
+  assert.match(result.issues[0].reason, /80% or higher/)
+})
+
+test('keeps syncing after Trakt rejects an individual resume point', async t => {
+  let now = Date.UTC(2026, 6, 17)
+  t.mock.method(Date, 'now', () => (now += 2_000))
+  let requestCount = 0
+  const fetchMock = t.mock.method(globalThis, 'fetch', async () => {
+    requestCount++
+    return requestCount === 1
+      ? new Response(JSON.stringify({ message: 'Invalid progress record.' }), {
+          status: 422,
+          statusText: 'Unprocessable Content',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      : new Response(JSON.stringify({ action: 'pause', progress: 40 }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' }
+        })
+  })
+
+  const bundle = createEmptyBundle()
+  bundle.progress.push(
+    movieProgress(50),
+    movieProgress(40, 'tt2015382')
+  )
+  const result = await pushMediaBridge({
+    connection: traktConnection(),
+    bundle,
+    scopes: { history: false, progress: true, library: false }
+  })
+
+  assert.equal(fetchMock.mock.callCount(), 2)
+  assert.equal(result.written.progress, 1)
+  assert.equal(result.issues.length, 1)
+  assert.equal(result.issues[0].scope, 'progress')
+  assert.match(result.issues[0].reason, /Invalid progress record/)
+})

--- a/docs/.vitepress/theme/components/mediaBridgeProviders.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeProviders.ts
@@ -14,17 +14,18 @@ import {
   type ProgressRecord,
   type ServiceId,
   type SyncScopes
-} from './mediaBridgeCore'
+} from './mediaBridgeCore.ts'
 import {
   mergeStremioWatchedVideoIds,
   readStremioWatchedVideoIds
-} from './stremioWatched'
+} from './stremioWatched.ts'
 
 const TRAKT_API = 'https://api.trakt.tv'
 const SIMKL_API = 'https://api.simkl.com'
 const STREMIO_API = 'https://api.strem.io/api'
 const CINEMETA_API = 'https://v3-cinemeta.strem.io'
 const NUVIO_API = 'https://api.nuvio.tv'
+const TRAKT_MAX_RESUME_PROGRESS = 79
 
 const SIMKL_EXTERNAL_ID_NAMESPACES = [
   'mal',
@@ -1004,8 +1005,22 @@ async function pushTrakt(options: PushOptions): Promise<PushResult> {
         issues.push({ scope: 'progress', status: 'unresolved', media: record.media, reason: 'Trakt progress needs a valid percentage or absolute position.' })
         continue
       }
+      if (percentage >= 80) {
+        // Trakt treats 80% and above as completed and no longer accepts it as
+        // playback state. Do not call /scrobble/stop because that would turn a
+        // progress-only transfer into a new watch-history event.
+        issues.push({
+          scope: 'progress',
+          status: 'unresolved',
+          media: record.media,
+          reason: 'Trakt cannot store resume points at 80% or higher; it treats them as watched. Transfer watch history to preserve the completed state.'
+        })
+        continue
+      }
       const payload: any = {
-        progress: Math.max(1, Math.min(99, Math.round(percentage))),
+        // /scrobble/stop returns a paused playback record from 1% through 79%.
+        // Cap after rounding so a 79.x% source never crosses into a scrobble.
+        progress: Math.max(1, Math.min(TRAKT_MAX_RESUME_PROGRESS, Math.round(percentage))),
         app_version: '2.0',
         app_date: new Date(record.updatedAt).toISOString().slice(0, 10)
       }
@@ -1053,8 +1068,21 @@ async function pushTrakt(options: PushOptions): Promise<PushResult> {
         issues.push({ scope: 'progress', status: 'unresolved', media: record.media, reason: 'The Trakt episode progress record has no season and episode number.' })
         continue
       }
-      await traktRequest(connection, '/scrobble/pause', {}, { method: 'POST', body: JSON.stringify(payload) })
-      written.progress++
+      try {
+        await traktRequest(connection, '/scrobble/stop', {}, { method: 'POST', body: JSON.stringify(payload) })
+        written.progress++
+      } catch (error: any) {
+        // Validation failures are specific to this media record. Keep writing
+        // the rest of the transfer instead of failing after earlier scopes
+        // have already committed successfully.
+        if (error?.status !== 422) throw error
+        issues.push({
+          scope: 'progress',
+          status: 'unresolved',
+          media: record.media,
+          reason: `Trakt rejected this resume point: ${errorDetail(error.body, error.message)}`
+        })
+      }
     }
     logTo(log, `Updated ${written.progress} Trakt resume points.`)
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "server:dev": "npm --prefix server run dev",
     "test:ai-markdown": "node --test docs/.vitepress/theme/components/aiMarkdown.test.ts",
     "test:badge-editor": "node --test docs/.vitepress/theme/components/badgeEditorUtils.test.ts",
-    "test:media-bridge": "node --test docs/.vitepress/theme/components/mediaBridgeCore.test.ts docs/.vitepress/theme/components/mediaBridgePlan.test.ts docs/.vitepress/theme/components/stremioWatched.test.ts",
+    "test:media-bridge": "node --test docs/.vitepress/theme/components/mediaBridgeCore.test.ts docs/.vitepress/theme/components/mediaBridgePlan.test.ts docs/.vitepress/theme/components/mediaBridgeProviders.test.ts docs/.vitepress/theme/components/stremioWatched.test.ts",
     "test:configuration-profiles": "node --test docs/.vitepress/theme/components/configurationProfiles.test.ts server/profile-shares.test.js",
     "test:profile-transfer": "node --test docs/.vitepress/theme/components/profileTransferMerge.test.ts"
   },


### PR DESCRIPTION
## What changed

- store supported Trakt resume points through `/scrobble/stop`, which produces paused playback for progress below 80%
- skip 80%+ resume points with a clear warning instead of turning them into duplicate watch-history events
- isolate record-level Trakt 422 responses so one invalid item does not abort the rest of a sync
- add provider regression tests and include them in the media bridge test command

## Root cause

The bridge sent a 99% resume point to `/scrobble/pause`. Trakt rejected it with HTTP 422 because completion-range progress must be scrobbled as watched. That exception escaped the per-record loop after history writes had already committed, leaving the sync partially complete.

## Impact

Nuvio-to-Trakt syncs now finish with actionable warnings for progress values Trakt cannot represent, while valid remaining history, progress, and library records continue syncing.

## Validation

- `npm run test:media-bridge` (32 passing)
- `npm run docs:build`
- `git diff --check`