### PR TITLE
Preserve complete Trakt history events

### DIFF
--- a/docs/.vitepress/theme/components/MediaSyncBridge.vue
+++ b/docs/.vitepress/theme/components/MediaSyncBridge.vue
@@ -787,6 +787,7 @@ async function preparePlan(
   const plan = planMediaBridgePreview({
     source: sourceResult.bundle,
     destination: destinationResult.bundle,
+    destinationService: destinationConnection.service,
     scopes: requestedScopes,
     mappingIssues
   })
@@ -905,6 +906,7 @@ async function runSync() {
       const remaining = planMediaBridgePreview({
         source: transfer,
         destination: verified.bundle,
+        destinationService: destinationConnection.service,
         scopes: verificationScopes
       })
       for (const scope of ['history', 'progress', 'library'] as const) {

--- a/docs/.vitepress/theme/components/mediaBridgeCore.test.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeCore.test.ts
@@ -7,6 +7,7 @@ import {
   buildStremioVideoId,
   canonicalEpisodeKey,
   canonicalMediaKey,
+  collapseHistoryToWatchedState,
   createEmptyBundle,
   dedupeBundle,
   episodeAliasKeys,
@@ -54,6 +55,10 @@ test('defines six services and generates every directional pair', () => {
     assert.deepEqual(SERVICE_DEFINITIONS[service].capabilities.write, ['plex', 'jellyfin'].includes(service)
       ? { history: true, progress: true, library: false }
       : { history: true, progress: true, library: true })
+    assert.equal(
+      SERVICE_DEFINITIONS[service].capabilities.historyWriteMode,
+      service === 'trakt' ? 'events' : 'state'
+    )
   }
 
   assert.equal(ROUTE_PAIRS.filter(route => route.sameService).length, 6)
@@ -217,13 +222,13 @@ test('preserves external anime IDs without sharing nested references', () => {
   assert.notEqual(deduped.history[0].media.ids.external, media.ids.external)
 })
 
-test('dedupes deterministically with latest records and preserved list provenance', () => {
+test('preserves history events while deduping state records deterministically', () => {
   const bundle: CanonicalBundle = createEmptyBundle()
   const sharedMovie = movie({ imdb: 'tt100' }, 'Shared')
 
   bundle.history.push(
-    { media: sharedMovie, watchedAt: 100, playCount: 1 },
-    { media: sharedMovie, watchedAt: 200, playCount: 2 }
+    { media: sharedMovie, watchedAt: 100, eventId: 10, playCount: 1 },
+    { media: sharedMovie, watchedAt: 200, eventId: 11, playCount: 2 }
   )
   bundle.progress.push(
     { media: sharedMovie, positionMs: 10, durationMs: 100, updatedAt: 300 },
@@ -246,9 +251,13 @@ test('dedupes deterministically with latest records and preserved list provenanc
   )
 
   const deduped = dedupeBundle(bundle)
-  assert.equal(deduped.history.length, 1)
+  assert.equal(deduped.history.length, 2)
   assert.equal(deduped.history[0].watchedAt, 200)
-  assert.equal(deduped.history[0].playCount, 2)
+  assert.deepEqual(deduped.history.map(record => record.eventId), [11, 10])
+  const watchedState = collapseHistoryToWatchedState(deduped.history)
+  assert.equal(watchedState.length, 1)
+  assert.equal(watchedState[0].eventId, 11)
+  assert.equal(watchedState[0].playCount, 2)
   assert.equal(deduped.progress.length, 1)
   assert.equal(deduped.progress[0].positionMs, 80)
   assert.equal(deduped.library.length, 1)

--- a/docs/.vitepress/theme/components/mediaBridgeCore.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeCore.ts
@@ -5,6 +5,7 @@ export type BridgeSlot = 'source' | 'destination'
 export type MediaKind = 'movie' | 'series'
 export type BridgeScope = 'history' | 'progress' | 'library'
 export type CanonicalListKind = 'watchlist' | 'collection' | 'library' | 'favorites' | 'other'
+export type HistoryWriteMode = 'events' | 'state'
 
 export interface SyncScopes {
   history: boolean
@@ -15,6 +16,7 @@ export interface SyncScopes {
 export interface ServiceCapabilities {
   read: SyncScopes
   write: SyncScopes
+  historyWriteMode: HistoryWriteMode
   profiles: boolean
   nativeLists: readonly CanonicalListKind[]
 }
@@ -46,6 +48,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { ...FULL_SCOPES },
+      historyWriteMode: 'state',
       profiles: false,
       nativeLists: ['watchlist']
     }
@@ -62,6 +65,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { ...FULL_SCOPES },
+      historyWriteMode: 'state',
       profiles: false,
       nativeLists: ['library']
     }
@@ -78,6 +82,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { ...FULL_SCOPES },
+      historyWriteMode: 'events',
       profiles: false,
       nativeLists: ['watchlist', 'collection']
     }
@@ -94,6 +99,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { history: true, progress: true, library: false },
+      historyWriteMode: 'state',
       profiles: false,
       nativeLists: ['library']
     }
@@ -110,6 +116,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { history: true, progress: true, library: false },
+      historyWriteMode: 'state',
       profiles: false,
       nativeLists: ['library']
     }
@@ -126,6 +133,7 @@ export const SERVICE_DEFINITIONS: Record<ServiceId, ServiceDefinition> = {
     capabilities: {
       read: { ...FULL_SCOPES },
       write: { ...FULL_SCOPES },
+      historyWriteMode: 'state',
       profiles: true,
       nativeLists: ['library']
     }
@@ -179,6 +187,7 @@ export interface ListProvenance extends RecordProvenance {
 export interface HistoryRecord {
   media: MediaRef
   watchedAt: number
+  eventId?: string | number
   playCount?: number
   source?: RecordProvenance
 }
@@ -596,6 +605,33 @@ function dedupeLatest<T extends { media: MediaRef }>(
     .map(([, entry]) => clone(entry.record))
 }
 
+function cloneHistory(records: readonly HistoryRecord[]): HistoryRecord[] {
+  return records
+    .map((record, index) => ({ record, index, time: normalizedTime(record.watchedAt) }))
+    .sort((left, right) => right.time - left.time || left.index - right.index)
+    .map(({ record }) => ({
+      ...record,
+      media: cloneMedia(record.media),
+      source: record.source ? { ...record.source } : undefined
+    }))
+}
+
+/**
+ * Reduces event history to the newest watched state per movie or episode.
+ * Only providers that cannot represent individual play events should use this.
+ */
+export function collapseHistoryToWatchedState(records: readonly HistoryRecord[]): HistoryRecord[] {
+  return dedupeLatest(
+    records,
+    record => record.watchedAt,
+    record => ({
+      ...record,
+      media: cloneMedia(record.media),
+      source: record.source ? { ...record.source } : undefined
+    })
+  )
+}
+
 function provenanceKey(provenance: ListProvenance): string {
   return [
     provenance.service,
@@ -661,15 +697,7 @@ function dedupeLibrary(records: readonly LibraryRecord[]): LibraryRecord[] {
 
 export function dedupeBundle(bundle: CanonicalBundle): CanonicalBundle {
   return {
-    history: dedupeLatest(
-      bundle.history,
-      record => record.watchedAt,
-      record => ({
-        ...record,
-        media: cloneMedia(record.media),
-        source: record.source ? { ...record.source } : undefined
-      })
-    ),
+    history: cloneHistory(bundle.history),
     progress: dedupeLatest(
       bundle.progress,
       record => record.updatedAt,

--- a/docs/.vitepress/theme/components/mediaBridgePlan.test.ts
+++ b/docs/.vitepress/theme/components/mediaBridgePlan.test.ts
@@ -112,11 +112,41 @@ test('keeps collapsed history idempotent when only provider replay counts differ
   source.history.push({ media: movie('tt104', 'Replay'), watchedAt: 100, playCount: 8 })
   destination.history.push({ media: movie('tt104', 'Replay'), watchedAt: 100, playCount: 1 })
 
-  const plan = planMediaBridgePreview({ source, destination, scopes: ALL_SCOPES })
+  const plan = planMediaBridgePreview({ source, destination, destinationService: 'simkl', scopes: ALL_SCOPES })
 
   assert.equal(plan.stats.alreadyPresent, 1)
   assert.equal(plan.stats.update, 0)
   assert.equal(plan.transfer.history.length, 0)
+})
+
+test('preserves replay events for Trakt and matches them as a timestamped multiset', () => {
+  const source = createEmptyBundle()
+  const destination = createEmptyBundle()
+  const replay = movie('tt105', 'Replay events')
+  source.history.push(
+    { media: replay, watchedAt: 100, eventId: 1001 },
+    { media: replay, watchedAt: 200, eventId: 1002 },
+    { media: replay, watchedAt: 200, eventId: 1003 }
+  )
+  destination.history.push(
+    { media: replay, watchedAt: 100, eventId: 2001 },
+    { media: replay, watchedAt: 200, eventId: 2002 }
+  )
+
+  const plan = planMediaBridgePreview({
+    source,
+    destination,
+    destinationService: 'trakt',
+    scopes: ALL_SCOPES
+  })
+
+  assert.equal(plan.stats.source, 3)
+  assert.equal(plan.stats.add, 1)
+  assert.equal(plan.stats.update, 0)
+  assert.equal(plan.stats.alreadyPresent, 2)
+  assert.equal(plan.transfer.history.length, 1)
+  assert.equal(plan.transfer.history[0].eventId, 1003)
+  assert.equal(plan.transfer.history[0].watchedAt, 200)
 })
 
 test('matches history, progress, and library through shared secondary IDs', () => {

--- a/docs/.vitepress/theme/components/mediaBridgePlan.ts
+++ b/docs/.vitepress/theme/components/mediaBridgePlan.ts
@@ -1,6 +1,8 @@
 import {
+  SERVICE_DEFINITIONS,
   canonicalEpisodeKey,
   canonicalMediaKey,
+  collapseHistoryToWatchedState,
   dedupeBundle,
   episodeAliasKeys,
   mediaAliasKeys,
@@ -14,6 +16,7 @@ import {
   type MediaIds,
   type MediaRef,
   type ProgressRecord,
+  type ServiceId,
   type SyncScopes
 } from './mediaBridgeCore.ts'
 
@@ -66,6 +69,7 @@ export interface MediaBridgePlanInput {
   source: CanonicalBundle
   destination: CanonicalBundle
   scopes: SyncScopes
+  destinationService?: ServiceId
   mappingIssues?: readonly ProviderMappingIssue[]
 }
 
@@ -329,10 +333,6 @@ function classifyRecord(
   if (scope === 'history') {
     const sourceHistory = source as HistoryRecord
     const destinationHistory = destination as HistoryRecord
-    // The bridge intentionally collapses replay events to the latest watched
-    // state. Some destinations (notably Trakt) create a fresh history event on
-    // every write, so comparing provider play counts here would make an
-    // otherwise-idempotent route add another play on every run.
     return sourceHistory.watchedAt > destinationHistory.watchedAt
       ? 'update'
       : 'already-present'
@@ -359,18 +359,20 @@ function recordsForScope(bundle: CanonicalBundle, scope: BridgeScope): ScopedRec
   return bundle.library
 }
 
-function destinationIndexes(bundle: CanonicalBundle): Record<BridgeScope, Map<string, ScopedRecord>> {
+type DestinationIndex = Map<string, ScopedRecord[]>
+
+function destinationIndexes(bundle: CanonicalBundle): Record<BridgeScope, DestinationIndex> {
   const result = {
-    history: new Map<string, ScopedRecord>(),
-    progress: new Map<string, ScopedRecord>(),
-    library: new Map<string, ScopedRecord>()
+    history: new Map<string, ScopedRecord[]>(),
+    progress: new Map<string, ScopedRecord[]>(),
+    library: new Map<string, ScopedRecord[]>()
   }
   for (const scope of Object.keys(result) as BridgeScope[]) {
     for (const record of recordsForScope(bundle, scope)) {
       for (const key of recordComparisonKeys(record.media, scope === 'progress')) {
-        // dedupeBundle orders latest records first; retain that winner if two
-        // records expose the same alias through different primary IDs.
-        if (!result[scope].has(key)) result[scope].set(key, record)
+        const records = result[scope].get(key) || []
+        records.push(record)
+        result[scope].set(key, records)
       }
     }
   }
@@ -378,13 +380,33 @@ function destinationIndexes(bundle: CanonicalBundle): Record<BridgeScope, Map<st
 }
 
 function findDestinationRecord(
-  index: Map<string, ScopedRecord>,
+  index: DestinationIndex,
   media: MediaRef,
   scope: BridgeScope
 ): ScopedRecord | undefined {
   for (const key of recordComparisonKeys(media, scope === 'progress')) {
-    const record = index.get(key)
+    const record = index.get(key)?.[0]
     if (record) return record
+  }
+  return undefined
+}
+
+function findDestinationHistoryEvent(
+  index: DestinationIndex,
+  media: MediaRef,
+  watchedAt: number,
+  consumed: Set<ScopedRecord>
+): HistoryRecord | undefined {
+  const candidates = new Set<ScopedRecord>()
+  for (const key of recordComparisonKeys(media)) {
+    for (const candidate of index.get(key) || []) candidates.add(candidate)
+  }
+  for (const candidate of candidates) {
+    if (consumed.has(candidate)) continue
+    const history = candidate as HistoryRecord
+    if (history.watchedAt !== watchedAt) continue
+    consumed.add(candidate)
+    return history
   }
   return undefined
 }
@@ -434,9 +456,17 @@ function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
 }
 
 export function planMediaBridgePreview(input: MediaBridgePlanInput): MediaBridgePreviewPlan {
+  const historyWriteMode = input.destinationService
+    ? SERVICE_DEFINITIONS[input.destinationService].capabilities.historyWriteMode
+    : 'state'
   const source = dedupeBundle(input.source)
   const destination = dedupeBundle(input.destination)
+  if (historyWriteMode === 'state') {
+    source.history = collapseHistoryToWatchedState(source.history)
+    destination.history = collapseHistoryToWatchedState(destination.history)
+  }
   const destinationByScope = destinationIndexes(destination)
+  const consumedHistoryEvents = new Set<ScopedRecord>()
   const mappingIssues = buildMappingIssueIndex(input.mappingIssues || [])
   const transfer: CanonicalBundle = { history: [], progress: [], library: [] }
   const rows: PendingRow[] = []
@@ -510,7 +540,14 @@ export function planMediaBridgePreview(input: MediaBridgePlanInput): MediaBridge
       }
 
       const plannedRecord = cloneRecordWithMedia(scope, sourceRecord, mappedMedia)
-      const destinationRecord = findDestinationRecord(destinationByScope[scope], mappedMedia, scope)
+      const destinationRecord = scope === 'history' && historyWriteMode === 'events'
+        ? findDestinationHistoryEvent(
+            destinationByScope.history,
+            mappedMedia,
+            (plannedRecord as HistoryRecord).watchedAt,
+            consumedHistoryEvents
+          )
+        : findDestinationRecord(destinationByScope[scope], mappedMedia, scope)
       const outcome = classifyRecord(scope, plannedRecord, destinationRecord)
       stats[outcome === 'already-present' ? 'alreadyPresent' : outcome]++
       if (remapped) stats.remapped++

--- a/docs/.vitepress/theme/components/mediaBridgeProviders.test.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeProviders.test.ts
@@ -387,6 +387,36 @@ test('confirms nested Trakt episode history counts from the sync response', asyn
   assert.deepEqual(result.issues, [])
 })
 
+test('submits every replay timestamp to Trakt as an individual history event', async t => {
+  const watchedAt = [
+    Date.UTC(2026, 6, 15),
+    Date.UTC(2026, 6, 16),
+    Date.UTC(2026, 6, 17)
+  ]
+  t.mock.method(globalThis, 'fetch', async (_input, init) => {
+    const body = JSON.parse(String(init?.body || '{}'))
+    assert.equal(body.movies.length, 3)
+    assert.deepEqual(body.movies.map((movie: any) => movie.watched_at), watchedAt.map(value => new Date(value).toISOString()))
+    return Response.json({
+      added: { movies: 3, episodes: 0 },
+      updated: { movies: 0, episodes: 0 },
+      not_found: { movies: [], shows: [], seasons: [], episodes: [] }
+    })
+  })
+  const bundle = createEmptyBundle()
+  bundle.history.push(...watchedAt.map(value => movieHistory('Replay', 'tt2015381', value)))
+
+  const result = await pushMediaBridge({
+    connection: traktConnection(),
+    bundle,
+    scopes: { history: true, progress: false, library: false }
+  })
+
+  assert.equal(result.written.history, 3)
+  assert.deepEqual(result.confirmedScopes, ['history'])
+  assert.deepEqual(result.issues, [])
+})
+
 test('falls back to destination verification for an incomplete Trakt history response', async t => {
   t.mock.method(globalThis, 'fetch', async () => Response.json({ success: true }))
   const bundle = createEmptyBundle()
@@ -403,7 +433,7 @@ test('falls back to destination verification for an incomplete Trakt history res
   assert.deepEqual(result.issues, [])
 })
 
-test('deduplicates Trakt replay history to the latest watched state', async t => {
+test('preserves Trakt replay history events and their IDs', async t => {
   t.mock.method(globalThis, 'fetch', async input => {
     const url = new URL(String(input))
     if (url.pathname !== '/users/me/history') throw new Error(`Unexpected request: ${url.pathname}`)
@@ -436,10 +466,11 @@ test('deduplicates Trakt replay history to the latest watched state', async t =>
   const source = await pullMediaBridge({ connection: traktConnection('source'), scopes })
   const destination = await pullMediaBridge({ connection: traktConnection('destination'), scopes })
 
-  assert.equal(source.bundle.history.length, 1)
+  assert.equal(source.bundle.history.length, 2)
   assert.equal(source.bundle.history[0].watchedAt, Date.parse('2026-07-17T12:00:00Z'))
+  assert.deepEqual(source.bundle.history.map(record => record.eventId), [2, 1])
   assert.deepEqual(source.issues, [])
-  assert.equal(destination.bundle.history.length, 1)
+  assert.equal(destination.bundle.history.length, 2)
   assert.deepEqual(destination.issues, [])
 })
 
@@ -523,6 +554,100 @@ test('reads every Trakt history page and maps episodes through their parent show
     '/users/me/history:1',
     '/users/me/history:2',
     '/users/me/history:3'
+  ])
+})
+
+test('exports all 4,000 paginated Trakt history events with event IDs and replay timestamps', async t => {
+  const totalEvents = 4_000
+  const serverLimit = 80
+  const pageCount = totalEvents / serverLimit
+  const requestedLimits: number[] = []
+  const fetchMock = t.mock.method(globalThis, 'fetch', async input => {
+    const url = new URL(String(input))
+    assert.equal(url.pathname, '/users/me/history')
+    const page = Number(url.searchParams.get('page'))
+    requestedLimits.push(Number(url.searchParams.get('limit')))
+    const firstIndex = (page - 1) * serverLimit
+    const rows = Array.from({ length: serverLimit }, (_, offset) => {
+      const index = firstIndex + offset
+      const watchedAt = new Date(Date.UTC(2020, 0, 1) + index * 1_000).toISOString()
+      return index % 2 === 0
+        ? {
+            id: index + 1,
+            watched_at: watchedAt,
+            action: 'watch',
+            type: 'movie',
+            movie: {
+              title: 'Repeated Movie',
+              year: 2020,
+              ids: { trakt: 1, imdb: 'tt0000001' }
+            }
+          }
+        : {
+            id: index + 1,
+            watched_at: watchedAt,
+            action: 'watch',
+            type: 'episode',
+            episode: { season: 1, number: 1, title: 'Pilot', ids: { trakt: 2 } },
+            show: {
+              title: 'Repeated Show',
+              year: 2020,
+              ids: { trakt: 3, imdb: 'tt0000003' }
+            }
+          }
+    })
+    return Response.json(rows, {
+      headers: {
+        'X-Pagination-Page': String(page),
+        'X-Pagination-Limit': String(serverLimit),
+        'X-Pagination-Page-Count': String(pageCount),
+        'X-Pagination-Item-Count': String(totalEvents)
+      }
+    })
+  })
+
+  const result = await pullMediaBridge({
+    connection: traktConnection('source'),
+    scopes: { history: true, progress: false, library: false }
+  })
+
+  assert.equal(fetchMock.mock.callCount(), pageCount)
+  assert.equal(requestedLimits[0], 100)
+  assert.ok(requestedLimits.slice(1).every(limit => limit === serverLimit))
+  assert.equal(result.bundle.history.length, totalEvents)
+  assert.equal(result.bundle.history[0].eventId, totalEvents)
+  assert.equal(result.bundle.history.at(-1)?.eventId, 1)
+  assert.equal(result.bundle.history.filter(record => record.media.kind === 'movie').length, 2_000)
+  assert.equal(result.bundle.history.filter(record => record.media.kind === 'series').length, 2_000)
+  assert.deepEqual(result.issues, [])
+})
+
+test('continues Trakt pagination to an empty page when pagination headers are unavailable', async t => {
+  const events = Array.from({ length: 5 }, (_, index) => ({
+    id: `event-${index + 1}`,
+    watched_at: new Date(Date.UTC(2026, 6, 17, index)).toISOString(),
+    type: 'movie',
+    movie: {
+      title: 'Server Limited',
+      year: 2026,
+      ids: { trakt: 10, imdb: 'tt0000010' }
+    }
+  }))
+  const fetchMock = t.mock.method(globalThis, 'fetch', async input => {
+    const url = new URL(String(input))
+    const page = Number(url.searchParams.get('page'))
+    return Response.json(events.slice((page - 1) * 2, page * 2))
+  })
+
+  const result = await pullMediaBridge({
+    connection: traktConnection('source'),
+    scopes: { history: true, progress: false, library: false }
+  })
+
+  assert.equal(fetchMock.mock.callCount(), 4)
+  assert.equal(result.bundle.history.length, 5)
+  assert.deepEqual(result.bundle.history.map(record => record.eventId), [
+    'event-5', 'event-4', 'event-3', 'event-2', 'event-1'
   ])
 })
 
@@ -1275,7 +1400,7 @@ test('treats a successful Stremio saved-title batch as confirmed', async t => {
   assert.deepEqual(result.issues, [])
 })
 
-test('treats an accepted Simkl history no-op as confirmed without requiring a newer timestamp', async t => {
+test('collapses replay events for Simkl watched state and confirms an accepted no-op', async t => {
   let requestBody: any = null
   const fetchMock = t.mock.method(globalThis, 'fetch', async (input, init) => {
     assert.equal(new URL(String(input)).pathname, '/sync/history')
@@ -1297,7 +1422,10 @@ test('treats an accepted Simkl history no-op as confirmed without requiring a ne
     })
   })
   const bundle = createEmptyBundle()
-  bundle.history.push(movieHistory('Already Watched', 'tt2015381', Date.UTC(2026, 6, 17)))
+  bundle.history.push(
+    movieHistory('Already Watched', 'tt2015381', Date.UTC(2026, 6, 16)),
+    movieHistory('Already Watched', 'tt2015381', Date.UTC(2026, 6, 17))
+  )
 
   const result = await pushMediaBridge({
     connection: simklConnection(),
@@ -1306,6 +1434,8 @@ test('treats an accepted Simkl history no-op as confirmed without requiring a ne
   })
 
   assert.equal(fetchMock.mock.callCount(), 1)
+  assert.equal(requestBody.movies.length, 1)
+  assert.equal(requestBody.movies[0].watched_at, '2026-07-17T00:00:00.000Z')
   assert.equal(result.written.history, 1)
   assert.equal(result.skipped?.history, undefined)
   assert.deepEqual(result.confirmedScopes, ['history'])

--- a/docs/.vitepress/theme/components/mediaBridgeProviders.ts
+++ b/docs/.vitepress/theme/components/mediaBridgeProviders.ts
@@ -1,4 +1,5 @@
 import {
+  collapseHistoryToWatchedState,
   createEmptyBundle,
   dedupeBundle,
   mediaAliasKeys,
@@ -598,8 +599,10 @@ async function traktGetAll(
 ): Promise<any[]> {
   const output: any[] = []
   const seenPageStarts = new Set<string>()
-  for (let page = 1; page <= 200; page++) {
-    const response = await traktRequest(connection, path, { ...params, page, limit: TRAKT_PAGE_SIZE })
+  let page = 1
+  let limit = TRAKT_PAGE_SIZE
+  while (true) {
+    const response = await traktRequest(connection, path, { ...params, page, limit })
     const rows = Array.isArray(response.data) ? response.data : []
     if (!rows.length) break
     // Some Trakt endpoints paginate without exposing their pagination headers
@@ -610,12 +613,13 @@ async function traktGetAll(
     if (seenPageStarts.has(pageStart)) break
     seenPageStarts.add(pageStart)
     output.push(...rows)
-    const pages = Number(
-      response.headers.get('x-pagination-page-count')
-      || response.headers.get('X-Pagination-Page-Count')
-      || 0
-    )
-    if (pages && page >= pages) break
+    const responsePage = Number(response.headers.get('x-pagination-page'))
+    const pageCount = Number(response.headers.get('x-pagination-page-count'))
+    const responseLimit = Number(response.headers.get('x-pagination-limit'))
+    const currentPage = Number.isInteger(responsePage) && responsePage > 0 ? responsePage : page
+    if (Number.isInteger(responseLimit) && responseLimit > 0) limit = responseLimit
+    if (Number.isInteger(pageCount) && pageCount > 0 && currentPage >= pageCount) break
+    page = currentPage >= page ? currentPage + 1 : page + 1
   }
   return output
 }
@@ -1612,7 +1616,7 @@ async function pushPlex(options: PushOptions): Promise<PushResult> {
   const confirmedScopes: BridgeScope[] = []
 
   if (scopes.history) {
-    for (const record of bundle.history) {
+    for (const record of collapseHistoryToWatchedState(bundle.history)) {
       const resolved = resolvePlexEntry(record.media, catalog, 'history')
       if (!resolved.entry) {
         skipped.history++
@@ -2041,7 +2045,7 @@ async function pushJellyfin(options: PushOptions): Promise<PushResult> {
   const confirmedScopes: BridgeScope[] = []
 
   if (scopes.history) {
-    for (const record of bundle.history) {
+    for (const record of collapseHistoryToWatchedState(bundle.history)) {
       const resolved = resolveJellyfinEntry(record.media, catalog, 'history')
       if (!resolved.entry) {
         skipped.history++
@@ -2171,6 +2175,7 @@ async function pullTrakt(options: PullOptions): Promise<PullResult> {
         bundle.history.push({
           media: mediaFromTrakt(item.movie, 'movie'),
           watchedAt: asEpochMs(item.watched_at),
+          eventId: typeof item.id === 'string' || typeof item.id === 'number' ? item.id : undefined,
           playCount: 1,
           source: provenance
         })
@@ -2192,6 +2197,7 @@ async function pullTrakt(options: PullOptions): Promise<PullResult> {
             episodeTitle: item.episode.title
           },
           watchedAt: asEpochMs(item.watched_at),
+          eventId: typeof item.id === 'string' || typeof item.id === 'number' ? item.id : undefined,
           playCount: 1,
           source: provenance
         })
@@ -2759,7 +2765,7 @@ async function pushNuvio(options: PushOptions): Promise<PushResult> {
 
   if (scopes.history && bundle.history.length) {
     const rows: any[] = []
-    for (const record of bundle.history) {
+    for (const record of collapseHistoryToWatchedState(bundle.history)) {
       const contentId = nuvioContentId(record.media)
       if (!contentId) {
         issues.push({ scope: 'history', status: 'unresolved', media: record.media, reason: 'Nuvio needs a supported content ID.' })
@@ -3193,7 +3199,7 @@ async function pushSimkl(options: PushOptions): Promise<PushResult> {
   const confirmedScopes: BridgeScope[] = []
 
   if (scopes.history && bundle.history.length) {
-    const grouped = groupSimklHistory(bundle.history)
+    const grouped = groupSimklHistory(collapseHistoryToWatchedState(bundle.history))
     issues.push(...grouped.issues)
     if (grouped.issues.length) skipped.history = grouped.issues.length
     const payloads = [
@@ -3613,7 +3619,9 @@ async function pushStremio(options: PushOptions): Promise<PushResult> {
     if (!byId.has(id)) byId.set(id, { history: [], progress: [], library: [], media: record.media })
     ;(byId.get(id)![scope] as any[]).push(record)
   }
-  if (scopes.history) bundle.history.forEach(record => addRecord('history', record))
+  if (scopes.history) {
+    collapseHistoryToWatchedState(bundle.history).forEach(record => addRecord('history', record))
+  }
   if (scopes.progress) {
     bundle.progress.forEach(record => {
       if (!absoluteProgress(record)) {


### PR DESCRIPTION
## What changed

- preserve every canonical history event, including Trakt history event IDs and timestamps
- declare per-destination history write semantics: Trakt accepts events; Simkl, Stremio, Plex, Jellyfin, and Nuvio receive collapsed watched state
- compare Trakt destination history as a timestamped multiset so duplicate replays remain idempotent
- honor Trakt's returned pagination page, page count, and limit while retaining empty-page and repeated-page fallbacks
- pass the destination service into preview and verification planning

## Why

The bridge imported per-event Trakt history but globally deduplicated it by media identity, reducing thousands of replay events to one latest watched state per title.

## Validation

- `npm run test:media-bridge` — 66 passed
- `npm run docs:build` — production build passed; internal links checked across 64 rendered pages
- regression coverage includes 4,000 Trakt history events over 50 server-limited pages and pagination without response headers