### PR TITLE
Add Windows settings and table layout styles

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -171,6 +171,16 @@ body {
   border-color: var(--vp-c-border);
 }
 
+@media (min-width: 769px) {
+  .settings-overview-page .vp-doc table:first-of-type {
+    table-layout: fixed;
+  }
+
+  .settings-overview-page .vp-doc table:first-of-type th:first-child {
+    width: 16%;
+  }
+}
+
 .vp-doc .custom-block {
   border-width: 1px;
   border-radius: 10px;

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1,18 +1,22 @@
+---
+pageClass: settings-overview-page
+---
+
 # Settings Breakdown
 
-Nuvio's settings allow for deep customization. Below is a detailed breakdown, noting differences between the **Mobile** and **Android TV** versions.
+Nuvio's settings allow for deep customization. Below is a detailed breakdown, noting differences between the **Mobile**, **Android TV**, and **Windows** versions.
 
 > [!IMPORTANT]
-> Anything not labeled [Android TV Only] or [Mobile Only] is a feature of both versions.
+> Anything not labeled [Android TV Only], [Mobile Only], or [Windows Only] is a feature of all versions.
 
 ## 1. General & UI
-| Setting | Mobile | Android TV |
-| :--- | :--- | :--- |
-| **Theme** | Select custom accent color palettes (White, Crimson, Ocean, Violet, Emerald, Amber, Rose). Toggle **AMOLED Black** to use pure black backgrounds for OLED screens. | Select custom accent color palettes (White, Crimson, Ocean, Violet, Emerald, Amber, Rose). Toggle **AMOLED Mode** and **Pure Black Surfaces** to use pure black app backgrounds and card surfaces. |
-| **Font & Language** | Adjust global App Language overrides. | Adjust global App Font family choices and App Language overrides. |
-| **Layout / Home Shelf** | Toggle the **Show Continue Watching** shelf on the Home screen. Select a base home card type: **Card** (TV-style landscape card), **Wide** (info-dense horizontal card), or **Poster** (artwork-first poster card). Toggle **Resume prompt on launch** popups. | Switch home dashboards between Modern View (with dedicated hero panels), Grid View, or Classic View. Toggle Fullscreen Hero Backdrops. Configure auto-collapsing sidebars. |
-| **Up Next Behavior** | Configure granular tracking rules: **Prefer Episode Thumbnails**, **Up Next From Furthest Episode** (disable for rewatches to use most recent), **Show Unaired Next Up Episodes**, and **Blur Unwatched** to avoid spoilers. | Configure series playback lines using *Prefer Binge Group* rules, *Reuse Binge Groups*, and variable *Next Episode Threshold Mode* percentages. |
-| **Poster Card Style** | Fine-tune card **Width** (Compact, Dense, Standard, Balanced, Comfort, Large) and **Corner Radius** (Sharp, Subtle, Classic, Rounded, Pill) with a real-time pixel size **Live Preview**. Toggle **Landscape Posters** and **Hide labels**. | Fine-tune card Width metrics (Compact to Large), Corner Radius geometries (Sharp to Pill), and hover **Backdrop Expand Delay** timers. Toggle Landscape Posters. |
+| Setting | Mobile | Android TV | Windows |
+| :--- | :--- | :--- | :--- |
+| **Theme** | Select custom accent color palettes (White, Crimson, Ocean, Violet, Emerald, Amber, Rose). Toggle **AMOLED Black** to use pure black backgrounds for OLED screens. | Select custom accent color palettes (White, Crimson, Ocean, Violet, Emerald, Amber, Rose). Toggle **AMOLED Black** to use pure black backgrounds for OLED screens. | Select custom accent color palettes (White, Crimson, Ocean, Violet, Emerald, Amber, Rose). Toggle **AMOLED Black** to use pure black backgrounds for OLED screens. |
+| **Font & Language** | Adjust global App Language overrides. | Adjust global App Font family choices and App Language overrides. | Adjust global App Language overrides. |
+| **Layout / Home Shelf** | Toggle the **Show Continue Watching** shelf on the Home screen. Select a base home card type: **Card** (TV-style landscape card), **Wide** (info-dense horizontal card), or **Poster** (artwork-first poster card). Toggle **Resume prompt on launch** popups. | Switch home dashboards between Modern View (with dedicated hero panels), Grid View, or Classic View. Toggle Fullscreen Hero Backdrops. Configure auto-collapsing sidebars. | Toggle the **Show Continue Watching** shelf on the Home screen. Select a base home card type. You can enable the **card depth effect**. Toggle **Resume prompt on launch** popups. |
+| **Up Next Behavior** | Configure granular tracking rules: **Prefer Episode Thumbnails**, **Up Next From Furthest Episode** (disable for rewatches to use most recent), **Show Unaired Next Up Episodes**, and **Blur Unwatched** to avoid spoilers. | Configure series playback lines using *Prefer Binge Group* rules, *Reuse Binge Groups*, and variable *Next Episode Threshold Mode* percentages. | Configure granular tracking rules: **Prefer Episode Thumbnails**, **Up Next From Furthest Episode** (disable for rewatches to use most recent), **Show Unaired Next Up Episodes**, and **Blur Unwatched** to avoid spoilers. |
+| **Poster Card Style** | Fine-tune card **Width** (Compact, Dense, Standard, Balanced, Comfort, Large) and **Corner Radius** (Sharp, Subtle, Classic, Rounded, Pill) with a real-time pixel size **Live Preview**. Toggle **Landscape Posters** and **Hide labels**. | Fine-tune card Width metrics (Compact to Large), Corner Radius geometries (Sharp to Pill), and hover **Backdrop Expand Delay** timers. Toggle Landscape Posters. | Fine-tune card Width metrics (Compact to Large), Corner Radius geometries (Sharp to Pill), and hover **Backdrop Expand Delay** timers. Toggle Landscape Posters. |
 
 [Back to top](#settings-breakdown)
 
@@ -23,12 +27,13 @@ Nuvio's settings allow for deep customization. Below is a detailed breakdown, no
 - **External Player:** Useful if you encounter codec issues. Nuvio can pass the stream to VLC, MX Player, or JustPlayer.
 - **Hardware Acceleration:** Toggle this if you experience stuttering on older devices.
 - **Auto-Play Next:** Automatically start the next episode in a series.
-- **Intro and Outro Skip:** Prioritizes segment database filters across IntroDB, AniSkip, and Anime Skip. Includes automated community timestamp submission tools [Mobile Only] alongside custom parental guidance Content Warnings and automated segment skipping filters [Android TV Only].
+- **RTX Video Super Resolution** [Windows Only]: Upscales low-resolution video using NVIDIA RTX AI Super Resolution.
+- **Intro and Outro Skip:** Prioritizes segment database filters across IntroDB, AniSkip, and Anime Skip. Includes automated community timestamp submission tools [Mobile Windows Only] alongside custom parental guidance Content Warnings and automated segment skipping filters [Android TV Only].
 - **Stream Selection & Auto-Play:** Configures connection handshakes using *Reuse Last Link*, *Last Link Cache Duration* thresholds, explicit *Selection Modes* (Auto-play first source, Manual list, or custom Regex text matching), scraper *Timeout* settings, and granular *Filtering Scopes* for plugins/addons.
 - **Binge Watching Options:** Customizes automated series playback chains via *Prefer Binge Group* rules, *Reuse Binge Groups*, variable *Next Episode Threshold Mode* percentages, and idle security prompts via *Are You Still Watching?* [Android TV Only].
 - **Subtitle and Audio Preferences:** Locks primary and secondary multi-track audio/subtitle languages, filters out non-preferred tracking layers, uses a *Skip Silence* trigger, and offers an *Enable downmix* route to crush multichannel surround sound into clear stereo speaker arrays.
 - **Subtitle Layout Adjustments:** Tailors caption scaling sizes, custom text/background color profiles, outline parameters, and *Vertical Offset*. Includes an experimental toggle to deploy the **libass rendering engine** for heavy ASS/SSA dynamic typesetting scripts.
-- **Interface & Control Overlays:** Features standard *Loading Overlays* to hide network lag. Includes passive informational *Pause Overlays* [Android TV Only], *OSD System Clocks* [Android TV Only], touchscreen *Hold To Speed / Hold Speed* scaling multipliers, and sliding vertical *Gesture Controls* for volume/brightness [Mobile Only].
+- **Interface & Control Overlays:** Features standard *Loading Overlays* to hide network lag. Includes passive informational *Pause Overlays*, *OSD System Clocks* [Android TV Only], touchscreen *Hold To Speed / Hold Speed* scaling multipliers, and sliding vertical *Gesture Controls* for volume/brightness [Mobile Only].
 
 [Back to top](#settings-breakdown)
 


### PR DESCRIPTION
Add a pageClass and responsive table CSS for the settings overview page, fixing table layout and setting the first column width on wider screens. Expand settings docs to include a Windows column and Windows-specific options (e.g., RTX Video Super Resolution), and update feature labels/notes to reflect Windows alongside Mobile and Android TV. Changes affect docs/.vitepress/theme/custom.css and docs/settings/index.md.